### PR TITLE
Report uncaught exceptions as errors with non-zero exit status

### DIFF
--- a/src/ordt/extract/JSpecModelExtractor.java
+++ b/src/ordt/extract/JSpecModelExtractor.java
@@ -113,8 +113,8 @@ public class JSpecModelExtractor extends JSpecBaseListener implements RegModelIn
         } catch (FileNotFoundException e) {
         	MsgUtils.errorExit("jspec file not found. "  + e.getMessage());
         } catch (IOException e) {
-            e.printStackTrace();
-        }		
+            MsgUtils.errorExit(e);
+        }
 	}
 	
 

--- a/src/ordt/extract/Ordt.java
+++ b/src/ordt/extract/Ordt.java
@@ -3,8 +3,6 @@
  */
 package ordt.extract;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -123,9 +121,7 @@ public class Ordt {
 	    	System.out.println("Ordt complete " + new Date());
 	    	System.exit(MsgUtils.getReturnCode());
 		} catch (Exception e) {
-			StringWriter sw = new StringWriter();
-			e.printStackTrace(new PrintWriter(sw));
-			MsgUtils.errorExit(sw.toString());
+			MsgUtils.errorExit(e);
 		}
     }
 

--- a/src/ordt/extract/Ordt.java
+++ b/src/ordt/extract/Ordt.java
@@ -3,6 +3,8 @@
  */
 package ordt.extract;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -121,8 +123,9 @@ public class Ordt {
 	    	System.out.println("Ordt complete " + new Date());
 	    	System.exit(MsgUtils.getReturnCode());
 		} catch (Exception e) {
-			//errorMessage("Read of rdl file " + inputFile + " failed");
-			e.printStackTrace();
+			StringWriter sw = new StringWriter();
+			e.printStackTrace(new PrintWriter(sw));
+			MsgUtils.errorExit(sw.toString());
 		}
     }
 

--- a/src/ordt/extract/RdlModelExtractor.java
+++ b/src/ordt/extract/RdlModelExtractor.java
@@ -109,8 +109,8 @@ public class RdlModelExtractor extends SystemRDLBaseListener implements RegModel
         } catch (FileNotFoundException e) {
         	MsgUtils.errorExit("rdl file not found. "  + e.getMessage());
         } catch (IOException e) {
-            e.printStackTrace();
-        }		
+            MsgUtils.errorExit(e);
+        }
 	}
 	
 

--- a/src/ordt/output/OutputBuilder.java
+++ b/src/ordt/output/OutputBuilder.java
@@ -1407,10 +1407,10 @@ public abstract class OutputBuilder implements OutputWriterIntf{
 		   try {
 			bw.write(MsgUtils.repeat(' ', indentLevel*2) + stmt +"\n");
 		} catch (IOException e) {
-			e.printStackTrace();
+			MsgUtils.errorExit(e);
 		}
 	}
-	
+
 	/** write multiple stmts to the specified BufferedWriter */
 	public void writeStmts(BufferedWriter bw, int indentLevel, List<String> outputLines) {
 		Iterator<String> iter = outputLines.iterator();

--- a/src/ordt/output/common/MsgUtils.java
+++ b/src/ordt/output/common/MsgUtils.java
@@ -1,5 +1,7 @@
 package ordt.output.common;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Date;
 
 public class MsgUtils {
@@ -8,6 +10,13 @@ public class MsgUtils {
 	private final static int ERROR_EXIT_RC = 8;
 	private static int returnCode = 0;
 	private static String progName = "Ordt";
+
+	/** display exception stack trace as error message and exit */
+	public static void errorExit(Throwable e) {
+		StringWriter sw = new StringWriter();
+		e.printStackTrace(new PrintWriter(sw));
+		errorExit(sw.toString());
+	}
 
 	/** display error message and exit */
 	public static void errorExit(String msg) {

--- a/src/ordt/output/common/SimpleOutputWriter.java
+++ b/src/ordt/output/common/SimpleOutputWriter.java
@@ -44,7 +44,7 @@ public class SimpleOutputWriter implements OutputWriterIntf {
 		   try {
 			bw.write(MsgUtils.repeat(' ', indentLevel*2) + stmt +"\n");
 		} catch (IOException e) {
-			e.printStackTrace();
+			MsgUtils.errorExit(e);
 		}
 	}
 

--- a/src/ordt/output/systemverilog/common/SystemVerilogModuleReader.java
+++ b/src/ordt/output/systemverilog/common/SystemVerilogModuleReader.java
@@ -87,8 +87,8 @@ public class SystemVerilogModuleReader extends SimpleSVBaseListener {
         } catch (FileNotFoundException e) {
         	MsgUtils.errorExit("file not found. "  + e.getMessage());
         } catch (IOException e) {
-            e.printStackTrace();
-        }		
+            MsgUtils.errorExit(e);
+        }
 	}
 
 	// ------- parser override methods

--- a/src/ordt/parameters/ExtParameters.java
+++ b/src/ordt/parameters/ExtParameters.java
@@ -314,8 +314,8 @@ public class ExtParameters extends ExtParmsBaseListener  {
         } catch (FileNotFoundException e) {
         	MsgUtils.errorExit("parameter file not found. "  + e.getMessage());
         } catch (IOException e) {
-            e.printStackTrace();
-        }		
+            MsgUtils.errorExit(e);
+        }
 	}
 
 	// ------------------- ExtParmsBaseListener override methods


### PR DESCRIPTION
## Summary
- Uncaught exceptions in `main()` were silently swallowed, returning exit code 0 to the caller
- Now captures the stack trace as a string and routes it through `MsgUtils.errorExit()`, which prints the error and exits with `ERROR_EXIT_RC`

## Test plan
- [x] Trigger a condition that causes an uncaught exception and verify the process exits with a non-zero status
- [x] Verify the stack trace appears in the error output

🤖 Generated with [Claude Code](https://claude.com/claude-code)